### PR TITLE
Exclude spec/requests from RSpec/FilePath

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -6,7 +6,7 @@ require:
 AllCops:
   NewCops: enable
   Exclude:
-    - 'vendor/**/*'
+    - "vendor/**/*"
     - "config/**/*"
     - "bin/**/*"
     - "db/structure.sql"
@@ -61,6 +61,10 @@ RSpec/StubbedMock:
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10
+
+RSpec/FilePath:
+  Exclude:
+    - "spec/requests/**/*"
 
 Metrics/BlockLength:
   Enabled: true


### PR DESCRIPTION
Exclude request specs from `RSpec/FilePath`.
Fuse prefer having constants in the request specs' `describe` but keeping the naming like request specs. E.g.

- `RSpec.describe Users::RegistrationsController`
- `spec/requests/users/registrations_spec.rb`

The `RSpec/FilePath` rule gives an error like the following with our setup:

```ruby
spec/requests/users/registrations_spec.rb:3:1: C: RSpec/FilePath: Spec path should end with users/registrations_controller*_spec.rb.
RSpec.describe Users::RegistrationsController do
```