### PR TITLE
Update the deprecated config RSpec/FilePath to RSpec/FilePathPathFormat

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -63,7 +63,7 @@ RSpec/StubbedMock:
 RSpec/MultipleMemoizedHelpers:
   Max: 20
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   Exclude:
     - "spec/requests/**/*"
 

--- a/rubocop-pave.gemspec
+++ b/rubocop-pave.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 1.36'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
-  spec.add_dependency 'rubocop-rspec'
+  spec.add_dependency 'rubocop-rspec', '~> 2.24'
 end


### PR DESCRIPTION
rubocop-rspec has deprecated `RSpec/FilePath`: https://github.com/rubocop/rubocop-rspec/blob/b99bf786d15d5e8b2b950307be8742980f1d09ed/CHANGELOG.md?plain=1#L7