### PR TITLE
Rubocop rspec version to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 group :test, :development do
-  gem 'rubocop-pave'
+  gem 'rubocop-pave', require: false
 end
 ```
 

--- a/default.yml
+++ b/default.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   NewCops: enable

--- a/rubocop-pave.gemspec
+++ b/rubocop-pave.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec', '~> 3.0.4'
+  spec.add_dependency 'rubocop-rspec_rails'
 end

--- a/rubocop-pave.gemspec
+++ b/rubocop-pave.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 1.36'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
-  spec.add_dependency 'rubocop-rspec', '~> 2.24'
+  spec.add_dependency 'rubocop-rspec', '~> 3.0.4'
 end


### PR DESCRIPTION
Update `rubocop-rspec` version to 3 and add the suggested `rubocop-rspec_rails` extension.